### PR TITLE
add some --disable options to allow us to build just parts of the whole distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,8 +14,8 @@ if BUILD_NGMATH
 NGMATH = ngmath
 endif
 
-if BUILD_NCAR2D
-NCAR2D = ncar2d
+if BUILD_NCARG2D
+NCARG2D = ncarg2d
 endif
 
 if BUILD_NCARVIEW

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,18 @@ EXTERNAL = external
 NI = ni
 endif
 
-SUBDIRS = $(EXTERNAL) common ngmath ncarg2d ncarview $(NI)
+if BUILD_NGMATH
+NGMATH = ngmath
+endif
+
+if BUILD_NCAR2D
+NCAR2D = ncar2d
+endif
+
+if BUILD_NCARVIEW
+NCARVIEW = ncarview
+endif
+
+SUBDIRS = $(EXTERNAL) common $(NGMATH) $(NCARG2D) $(NCARVIEW) $(NI)
 
 EXTRA_DIST = COPYING

--- a/common/src/libncarg_c/Makefile.am
+++ b/common/src/libncarg_c/Makefile.am
@@ -19,6 +19,10 @@ noinst_HEADERS = options.h ncarg_path.h
 
 include_HEADERS = c.h
 
+# Parallel builds don't currently work due to the argget.f target
+# below. This target may be rewritten with the BUILT_SOURCE primary
+# and then parallel builds would (probably) work.
+.NOTPARALLEL:
 argget.f:argget.f.sed
 	cp $< $*.F
 	$(CPP) $(CPPFLAGS) -o $@ $*.F

--- a/configure.ac
+++ b/configure.ac
@@ -56,17 +56,17 @@ if test x$enable_ngmath = xno; then
    enable_ncar2d=no
 fi
 
-# Does the user want to build NCAR2D?
-AC_MSG_CHECKING([whether we should build NCAR2D])
-AC_ARG_ENABLE([ncar2d], [AS_HELP_STRING([--disable-ncar2d],
-              [do not build with NCAR2D])])
-test "x$enable_ncar2d" = xno || enable_ncar2d=yes
-AC_MSG_RESULT([$enable_ncar2d])
-AM_CONDITIONAL(BUILD_NCAR2D, [test x$enable_ncar2d = xyes])
-if test $enable_ngmath = no -a $enable_ncar2d = yes; then
-   AC_MSG_ERROR([Cannot build NCAR2D if NGMATH is disabled.])
+# Does the user want to build NCARG2D?
+AC_MSG_CHECKING([whether we should build NCARG2D])
+AC_ARG_ENABLE([ncarg2d], [AS_HELP_STRING([--disable-ncarg2d],
+              [do not build with NCARG2D])])
+test "x$enable_ncarg2d" = xno || enable_ncarg2d=yes
+AC_MSG_RESULT([$enable_ncarg2d])
+AM_CONDITIONAL(BUILD_NCARG2D, [test x$enable_ncarg2d = xyes])
+if test $enable_ngmath = no -a $enable_ncarg2d = yes; then
+   AC_MSG_ERROR([Cannot build NCARG2D if NGMATH is disabled.])
 fi
-if test x$enable_ncar2d = xno; then
+if test x$enable_ncarg2d = xno; then
    enable_ncarview=no
 fi
 
@@ -77,8 +77,8 @@ AC_ARG_ENABLE([ncarview], [AS_HELP_STRING([--disable-ncarview],
 test "x$enable_ncarview" = xno || enable_ncarview=yes
 AC_MSG_RESULT([$enable_ncarview])
 AM_CONDITIONAL(BUILD_NCARVIEW, [test x$enable_ncarview = xyes])
-if test $enable_ncar2d = no -a $enable_ncarview = yes; then
-   AC_MSG_ERROR([Cannot build NCARVIEW if NCAR2D is disabled.])
+if test $enable_ncarg2d = no -a $enable_ncarview = yes; then
+   AC_MSG_ERROR([Cannot build NCARVIEW if NCARG2D is disabled.])
 fi
 if test x$enable_ncarview = xno; then
    enable_ncl=no

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,22 @@ AC_PROG_INSTALL
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 
+# Does the user want to build NGMATH?
+AC_MSG_CHECKING([whether we should build NGMATH])
+AC_ARG_ENABLE([ngmath], [AS_HELP_STRING([--disable-ngmath],
+              [do not build with NGMATH (disables most of build)])])
+test "x$enable_ngmath" = xno || enable_ngmath=yes
+AC_MSG_RESULT([$enable_ngmath])
+AM_CONDITIONAL(BUILD_NGMATH, [test x$enable_ngmath = xyes])
+if test x$enable_ngmath = xno; then
+   enable_ncl=no
+   AM_CONDITIONAL(BUILD_NCAR2D, [1])
+   AM_CONDITIONAL(BUILD_NCARVIEW, [1])
+else
+   AM_CONDITIONAL(BUILD_NCAR2D, [0])
+   AM_CONDITIONAL(BUILD_NCARVIEW, [0])
+fi
+
 # Does the user want to build NCL?
 AC_MSG_CHECKING([whether we should build NCL])
 AC_ARG_ENABLE([ncl], [AS_HELP_STRING([--disable-ncl],
@@ -52,6 +68,9 @@ AC_ARG_ENABLE([ncl], [AS_HELP_STRING([--disable-ncl],
 test "x$enable_ncl" = xno || enable_ncl=yes
 AC_MSG_RESULT([$enable_ncl])
 AM_CONDITIONAL(BUILD_NCL, [test x$enable_ncl = xyes])
+if test $enable_ngmath = no -a $enable_ncl = yes; then
+   AC_MSG_ERROR([Cannot build NCL if NGMATH is disabled.])
+fi
 
 # Make sure to check for Xlibs in this old directory.
 AC_CHECK_FILE([/usr/X11R6/lib], [LDFLAGS="-L/usr/X11R6/lib"])

--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,6 @@ AC_MSG_RESULT([$enable_ngmath])
 AM_CONDITIONAL(BUILD_NGMATH, [test x$enable_ngmath = xyes])
 if test x$enable_ngmath = xno; then
    enable_ncar2d=no
-   enable_ncarview=no
-   enable_ncl=no
 fi
 
 # Does the user want to build NCAR2D?
@@ -68,6 +66,9 @@ AM_CONDITIONAL(BUILD_NCAR2D, [test x$enable_ncar2d = xyes])
 if test $enable_ngmath = no -a $enable_ncar2d = yes; then
    AC_MSG_ERROR([Cannot build NCAR2D if NGMATH is disabled.])
 fi
+if test x$enable_ncar2d = xno; then
+   enable_ncarview=no
+fi
 
 # Does the user want to build NCARVIEW?
 AC_MSG_CHECKING([whether we should build NCARVIEW])
@@ -76,8 +77,11 @@ AC_ARG_ENABLE([ncarview], [AS_HELP_STRING([--disable-ncarview],
 test "x$enable_ncarview" = xno || enable_ncarview=yes
 AC_MSG_RESULT([$enable_ncarview])
 AM_CONDITIONAL(BUILD_NCARVIEW, [test x$enable_ncarview = xyes])
-if test $enable_ncarr2d = no -a $enable_ncarview = yes; then
+if test $enable_ncar2d = no -a $enable_ncarview = yes; then
    AC_MSG_ERROR([Cannot build NCARVIEW if NCAR2D is disabled.])
+fi
+if test x$enable_ncarview = xno; then
+   enable_ncl=no
 fi
 
 # Does the user want to build NCL?

--- a/configure.ac
+++ b/configure.ac
@@ -53,12 +53,31 @@ test "x$enable_ngmath" = xno || enable_ngmath=yes
 AC_MSG_RESULT([$enable_ngmath])
 AM_CONDITIONAL(BUILD_NGMATH, [test x$enable_ngmath = xyes])
 if test x$enable_ngmath = xno; then
+   enable_ncar2d=no
+   enable_ncarview=no
    enable_ncl=no
-   AM_CONDITIONAL(BUILD_NCAR2D, [1])
-   AM_CONDITIONAL(BUILD_NCARVIEW, [1])
-else
-   AM_CONDITIONAL(BUILD_NCAR2D, [0])
-   AM_CONDITIONAL(BUILD_NCARVIEW, [0])
+fi
+
+# Does the user want to build NCAR2D?
+AC_MSG_CHECKING([whether we should build NCAR2D])
+AC_ARG_ENABLE([ncar2d], [AS_HELP_STRING([--disable-ncar2d],
+              [do not build with NCAR2D])])
+test "x$enable_ncar2d" = xno || enable_ncar2d=yes
+AC_MSG_RESULT([$enable_ncar2d])
+AM_CONDITIONAL(BUILD_NCAR2D, [test x$enable_ncar2d = xyes])
+if test $enable_ngmath = no -a $enable_ncar2d = yes; then
+   AC_MSG_ERROR([Cannot build NCAR2D if NGMATH is disabled.])
+fi
+
+# Does the user want to build NCARVIEW?
+AC_MSG_CHECKING([whether we should build NCARVIEW])
+AC_ARG_ENABLE([ncarview], [AS_HELP_STRING([--disable-ncarview],
+              [do not build with NCARVIEW])])
+test "x$enable_ncarview" = xno || enable_ncarview=yes
+AC_MSG_RESULT([$enable_ncarview])
+AM_CONDITIONAL(BUILD_NCARVIEW, [test x$enable_ncarview = xyes])
+if test $enable_ncarr2d = no -a $enable_ncarview = yes; then
+   AC_MSG_ERROR([Cannot build NCARVIEW if NCAR2D is disabled.])
 fi
 
 # Does the user want to build NCL?
@@ -68,8 +87,8 @@ AC_ARG_ENABLE([ncl], [AS_HELP_STRING([--disable-ncl],
 test "x$enable_ncl" = xno || enable_ncl=yes
 AC_MSG_RESULT([$enable_ncl])
 AM_CONDITIONAL(BUILD_NCL, [test x$enable_ncl = xyes])
-if test $enable_ngmath = no -a $enable_ncl = yes; then
-   AC_MSG_ERROR([Cannot build NCL if NGMATH is disabled.])
+if test $enable_ncarview = no -a $enable_ncl = yes; then
+   AC_MSG_ERROR([Cannot build NCL if NCARVIEW is disabled.])
 fi
 
 # Make sure to check for Xlibs in this old directory.

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ test "x$enable_ngmath" = xno || enable_ngmath=yes
 AC_MSG_RESULT([$enable_ngmath])
 AM_CONDITIONAL(BUILD_NGMATH, [test x$enable_ngmath = xyes])
 if test x$enable_ngmath = xno; then
-   enable_ncar2d=no
+   enable_ncarg2d=no
 fi
 
 # Does the user want to build NCARG2D?


### PR DESCRIPTION
In order to help us break down this giant build into management pieces I have added three disable options to the configure script, --disable-ngmath, --disable-ncar2d and --disable-ncarview.

As we can see in the top-level Makefile.am, the following directories are built:

`SUBDIRS = $(EXTERNAL) common $(NGMATH) $(NCARG2D) $(NCARVIEW) $(NI)
`
With the new options, using --disable-ngmath turns off everything but the build of the code in the common directory. Let's see if we can get that working OK before moving on to NGMATH, then we will add NCAR2D, etc.

So after merging this PR to the autotools branch, you should be able to run something like this:

`autoreconf -i && FFLAGS=-fno-range-check CPPFLAGS='-I/usr/local/netcdf-c-4.6.2/include -I/usr/include/freetype2' LDFLAGS='-L/usr/local/netcdf-c-4.6.2/lib' ./configure --disable-ngmath --prefix=/home/ed/test_ncarg && make install`

(With paths adjusted to match your install paths.)

When I run this it builds and installs some libraries in /home/ed/test_ncarg (as indicated by the --prefix argument to configure.)

Can you run this, make sure it all works for you, and then look at what is installed to see if it matches your expectations? Note that this builds both shared and static libraries. Use --disable-shared if you just want the static ones. Here's what I see in my install directories:


```
ed@mikado:~/ncl$ cd ~/test_ncarg/
ed@mikado:~/test_ncarg$ ls
bin  include  lib
ed@mikado:~/test_ncarg$ ls -l bin
total 280
-rwxr-xr-x 1 ed ed 117504 Feb  9 08:33 fontc
-rwxr-xr-x 1 ed ed 149768 Feb  9 08:33 graphc
-rwxr-xr-x 1 ed ed  13408 Feb  9 08:33 ncargpath
ed@mikado:~/test_ncarg$ ls -l include
total 12
-rw-r--r-- 1 ed ed 11615 Feb  9 08:33 c.h
ed@mikado:~/test_ncarg$ ls -l lib
total 516
-rw-r--r-- 1 ed ed 334752 Feb  9 08:33 libncarg_c.a
-rwxr-xr-x 1 ed ed   1365 Feb  9 08:33 libncarg_c.la
lrwxrwxrwx 1 ed ed     19 Feb  9 08:33 libncarg_c.so -> libncarg_c.so.1.0.0
lrwxrwxrwx 1 ed ed     19 Feb  9 08:33 libncarg_c.so.1 -> libncarg_c.so.1.0.0
-rwxr-xr-x 1 ed ed 181584 Feb  9 08:33 libncarg_c.so.1.0.0
drwxrwxr-x 4 ed ed   4096 Feb  9 08:33 ncarg
ed@mikado:~/test_ncarg$ ls -l lib/ncarg/
total 8
drwxrwxr-x 2 ed ed 4096 Feb  9 08:33 fontcaps
drwxrwxr-x 2 ed ed 4096 Feb  9 08:33 graphcaps
ed@mikado:~/test_ncarg$ ls -l lib/ncarg/fontcaps/
total 596
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font1
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font10
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font11
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font12
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font13
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font14
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font15
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font16
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font17
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font18
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font19
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font2
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font20
-rw-r--r-- 1 ed ed  6144 Feb  9 08:33 font21
-rw-r--r-- 1 ed ed  7320 Feb  9 08:33 font22
-rw-r--r-- 1 ed ed  9836 Feb  9 08:33 font25
-rw-r--r-- 1 ed ed 10492 Feb  9 08:33 font26
-rw-r--r-- 1 ed ed  8660 Feb  9 08:33 font29
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font3
-rw-r--r-- 1 ed ed  8528 Feb  9 08:33 font30
-rw-r--r-- 1 ed ed 10116 Feb  9 08:33 font33
-rw-r--r-- 1 ed ed  6640 Feb  9 08:33 font34
-rw-r--r-- 1 ed ed  8316 Feb  9 08:33 font35
-rw-r--r-- 1 ed ed 10652 Feb  9 08:33 font36
-rw-r--r-- 1 ed ed  6392 Feb  9 08:33 font37
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font4
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font5
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font6
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font7
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font8
-rw-r--r-- 1 ed ed 22400 Feb  9 08:33 font9
ed@mikado:~/test_ncarg$ ls -l lib/ncarg/graphcaps/
total 320
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 qms800
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 r6211
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 s100
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4010
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4025
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4105
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4107
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4107.seg
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4115
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 t4115.seg
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 tal1590
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 tekalike
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 versaterm
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt100
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt125
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt220
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt240
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt330
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt340
-rw-r--r-- 1 ed ed 14400 Feb  9 08:33 vt340w

```

We can easily add a test here if you can give me a program that uses this library and returns 0 for success and non-zero for failure.