### PR TITLE
Fix compilation with -Werror=format-security

### DIFF
--- a/ni/src/lib/nfp/ripW.c
+++ b/ni/src/lib/nfp/ripW.c
@@ -533,7 +533,7 @@ NhlErrorTypes rip_cape_3d_W( void )
 
 /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 
@@ -1080,7 +1080,7 @@ NhlErrorTypes rip_cape_2d_W( void )
 
 /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 

--- a/ni/src/lib/nfp/wrfW.c
+++ b/ni/src/lib/nfp/wrfW.c
@@ -1514,7 +1514,7 @@ NhlErrorTypes wrf_slp_W( void )
 
     /* Terminate if there was an error */
     if (errstat != 0) {
-    	fprintf(stderr, errmsg);
+    	fputs(errmsg, stderr);
     	exit(errstat);
     }
 /*
@@ -9221,7 +9221,7 @@ NhlErrorTypes wrf_ll_to_ij_W( void )
 
     /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 
@@ -9867,7 +9867,7 @@ NhlErrorTypes wrf_ij_to_ll_W( void )
 
     /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 
@@ -10529,7 +10529,7 @@ NhlErrorTypes wrf_cape_3d_W( void )
 
 /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 
@@ -11232,7 +11232,7 @@ NhlErrorTypes wrf_cape_2d_W( void )
 
     /* Terminate if there was an error */
     if (errstat != 0) {
-      fprintf(stderr, errmsg);
+      fputs(errmsg, stderr);
       exit(errstat);
     }
 /*
@@ -13620,7 +13620,7 @@ NhlErrorTypes wrf_wetbulb_W( void )
 
     /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 

--- a/ni/src/lib/nfp/wrf_vinterpW.c
+++ b/ni/src/lib/nfp/wrf_vinterpW.c
@@ -819,7 +819,7 @@ NclBasicDataTypes type_ter;
 								   &errstat, errmsg, ERRLEN);
     /* Terminate if there was an error */
 	if (errstat != 0) {
-		fprintf(stderr, errmsg);
+		fputs(errmsg, stderr);
 		exit(errstat);
 	}
 


### PR DESCRIPTION
Fedora compiles with -Werror=format-security.  NCL 6.6.2 fails with:
```
gcc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection -std=c99 -fPIC -fno-strict-aliasing -fopenmp  -I../../ncl -I../../../.././include -I/usr/include/hdf -I/usr/include/netcdf -I/usr/include/udunits2 -I/usr/include/freetype2 -I/usr/include/gdal  -DBuildUdunits    -DBuildGDAL -DBuildEEMD  -D_ISOC99_SOURCE -D_POSIX_SOURCE -D_XOPEN_SOURCE -DByteSwapped -DNeedFuncProto    -c -o wrapper.o wrapper.c
BUILDSTDERR: gcc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specsutilW.c: In function 'replace_ieeenan_W':
BUILDSTDERR: utilW.c:285:8: warning: variable 'iopt' set but not used [-Wunused-but-set-variable]
BUILDSTDERR:   285 |   int *iopt, has_missing_x;
BUILDSTDERR:       |        ^~~~
BUILDSTDERR: wrfW.c: In function 'wrf_slp_W':
BUILDSTDERR: wrfW.c:1517:6: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR:  1517 |      fprintf(stderr, errmsg);
BUILDSTDERR:       |      ^~~~~~~
BUILDSTDERR: wrfW.c: In function 'wrf_pvo_W':
BUILDSTDERR: wrfW.c:5375:8: warning: variable 'opt' set but not used [-Wunused-but-set-variable]
BUILDSTDERR:  5375 |   int *opt;
BUILDSTDERR:       |        ^~~
BUILDSTDERR: wrfW.c: In function 'wrf_avo_W':
BUILDSTDERR: wrfW.c:6202:8: warning: variable 'opt' set but not used [-Wunused-but-set-variable]
BUILDSTDERR:  6202 |   int *opt;
BUILDSTDERR:       |        ^~~
BUILDSTDERR: wrfW.c: In function 'wrf_updraft_helicity_W':
BUILDSTDERR: wrfW.c:7992:12: warning: variable 'opt' set but not used [-Wunused-but-set-variable]
BUILDSTDERR:  7992 |   logical *opt;
BUILDSTDERR:       |            ^~~
BUILDSTDERR: wrfW.c: In function 'wrf_ll_to_ij_W':
BUILDSTDERR: wrfW.c:9224:3: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR:  9224 |   fprintf(stderr, errmsg);
BUILDSTDERR:       |   ^~~~~~~
BUILDSTDERR: wrfW.c:8703:12: warning: variable 'opt' set but not used [-Wunused-but-set-variable]
BUILDSTDERR:  8703 |   logical *opt;
BUILDSTDERR:       |            ^~~
BUILDSTDERR: wrfW.c: In function 'wrf_ij_to_ll_W':
BUILDSTDERR: wrfW.c:9870:3: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR:  9870 |   fprintf(stderr, errmsg);
BUILDSTDERR:       |   ^~~~~~~
BUILDSTDERR: wrfW.c:9339:12: warning: variable 'opt' set but not used [-Wunused-but-set-variable]
BUILDSTDERR:  9339 |   logical *opt;
BUILDSTDERR:       |            ^~~
BUILDSTDERR: wrfW.c: In function 'wrf_cape_3d_W':
BUILDSTDERR: wrfW.c:10532:3: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR: 10532 |   fprintf(stderr, errmsg);
BUILDSTDERR:       |   ^~~~~~~
BUILDSTDERR: wrfW.c: In function 'wrf_cape_2d_W':
BUILDSTDERR: wrfW.c:11235:7: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR: 11235 |       fprintf(stderr, errmsg);
BUILDSTDERR:       |       ^~~~~~~
BUILDSTDERR: wrfW.c: In function 'wrf_wps_close_int_W':
BUILDSTDERR: wrfW.c:11905:8: warning: variable 'istatus' set but not used [-Wunused-but-set-variable]
BUILDSTDERR: 11905 |   int *istatus;
BUILDSTDERR:       |        ^~~~~~~
BUILDSTDERR: wrfW.c: In function 'wrf_wetbulb_W':
BUILDSTDERR: wrfW.c:13623:3: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR: 13623 |   fprintf(stderr, errmsg);
BUILDSTDERR:       |   ^~~~~~~
BUILDSTDERR: wrfW.c: In function 'wrf_wps_read_int_W':
BUILDSTDERR: wrfW.c:12435:19: warning: 'max_ny' may be used uninitialized in this function [-Wmaybe-uninitialized]
BUILDSTDERR: 12435 |   dsizes_slab[1]  = max_ny;
BUILDSTDERR:       |   ~~~~~~~~~~~~~~~~^~~~~~~~
BUILDSTDERR: wrfW.c:12436:19: warning: 'max_nx' may be used uninitialized in this function [-Wmaybe-uninitialized]
BUILDSTDERR: 12436 |   dsizes_slab[2]  = max_nx;
BUILDSTDERR:       |   ~~~~~~~~~~~~~~~~^~~~~~~~
BUILDSTDERR: wrfW.c:12424:3: warning: 'slab_s' may be used uninitialized in this function [-Wmaybe-uninitialized]
BUILDSTDERR: 12424 |   free(slab_s);
BUILDSTDERR:       |   ^~~~~~~~~~~~
BUILDSTDERR: cc1: some warnings being treated as errors
BUILDSTDERR: make[5]: *** [Makefile:579: wrfW.o] Error 1
```
This commit fixes that.