### PR TITLE
enable build on FreeBSD

### DIFF
--- a/config/FreeBSD
+++ b/config/FreeBSD
@@ -10,23 +10,27 @@
  */
 
 #define    HdfDefines  -DFreeBSD
-#define    StdDefines  -DSYSV -D_POSIX_SOURCE -D_XOPEN_SOURCE -DByteSwapped
+#define    StdDefines  -DSYSV -D_XOPEN_SOURCE -DByteSwapped -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 #define    ByteSwapped
 #define    Cstatic
 #define    Cdynamic
 #define    CppCommand  '/usr/bin/cpp -traditional'
 #define    CCompiler   cc
-#define    FCompiler   f77
-#define    CtoFLibraries   -lg2c -lgcc -lm
-#define    CcOptions       -ansi
+#define    CxxCompiler c\+\+
+#define    FCompiler   gfortran9
+#define    CtoFLibraries -L/usr/local/lib/gcc9 -lgfortran -lquadmath
+#define    FcOptions -fno-range-check -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables
+#define    CcOptions -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables
+#define    COptimizeFlag -O2
+#define    FOptimizeFlag -O2
 #define    XToolLibrary    -lXt -lSM -lICE
 #define    BuildShared NO
 #define    XLibrary    -lX11 -lXext
 
-#define    ArchRecLibSearch    -L/usr/X11R6/lib -L/usr/local/lib
-#define    ArchRecIncSearch    -I/usr/X11R6/include -I/usr/local/include
+#define    ArchRecLibSearch    -L/usr/local/lib
+#define    ArchRecIncSearch    -I/usr/local/include -I/usr/local/include/freetype2
 
-FC ?= $(F77)
+FC = /usr/local/bin/gfortran9
 
 /*************** Redefine Macros from Rules ********************************/
 

--- a/config/ymake
+++ b/config/ymake
@@ -391,6 +391,7 @@ case    FreeBSD:
         switch ("$mach")
         case    i*86:
         case    i*64:
+        case    amd64:
         case    alpha:
             set model   = $mach
             set arch    = $mach

--- a/ncarview/src/bin/ictrans/yMakefile
+++ b/ncarview/src/bin/ictrans/yMakefile
@@ -31,7 +31,7 @@ DEP_LIBS	=	$(DEPICTRANSLIB) $(DEPCTRANSLIB) $(DEPCGMLIB) \
 MORE_LIBS	= -lmalloc
 #endif
 
-EXTRA_LIBS	= $(X11LIBS) $(SUNLIBS) $(NETCDFLIB) $(HDFLIB) $(CTOFLIBS)
+EXTRA_LIBS	= $(X11LIBS) $(SUNLIBS) $(NETCDFLIB) $(HDFLIB) $(CTOFLIBS) -lm
 SYS_LIBS	=  $(MORE_LIBS)
 
 SRCS		= main.c 
@@ -39,9 +39,6 @@ OBJS		= main.o
 
 CProgram($(MYNAME),$(OBJS),$(DEP_LIBS))
 DependTarget($(SRCS))
-
-all-local::
-	@$(CAT) Copyright
 
 lint: $(HDR) $(SRCS)
 	lint $(CDEFINES) $(LINTLIBS) $(SRCS)  1> lint.out 2>&1

--- a/ni/src/ncl/FileSupport.c
+++ b/ni/src/ncl/FileSupport.c
@@ -35,7 +35,11 @@ short    NCLuseAFS;
 
 #include <ctype.h>
 #include <unistd.h>
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
 #include <alloca.h>
+#endif
 #include <netcdf.h>
 
 #ifdef BuildHDF4

--- a/ni/src/ncl/NclAdvancedFile.h
+++ b/ni/src/ncl/NclAdvancedFile.h
@@ -24,7 +24,11 @@
 #include <sys/stat.h>
 #include <assert.h>
 #include <math.h>
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
 #include <alloca.h>
+#endif
 #include "defs.h"
 #include "Symbol.h"
 #include "NclVar.h"


### PR DESCRIPTION
This commit enables build on FreeBSD 12.1-RELEASE with cc/c++ (clang) and gfortran9. In addition I edited config/Project and external/yMakefile to use openblas and lapack instead of blas/lapack_ncl.

[config-Project.txt](https://github.com/NCAR/ncl/files/3966092/config-Project.txt)
[external-yMakefile.txt](https://github.com/NCAR/ncl/files/3966093/external-yMakefile.txt)

