### PR TITLE
Add support for Apple arm64

### DIFF
--- a/README.apple_m1
+++ b/README.apple_m1
@@ -6,4 +6,8 @@ For Configure, my library and include settings are:
 
 /opt/X11/include /opt/X11/include/freetype2 /Users/Shared/opt/local/netcdf480ser/include /Users/Shared/homebrew/include
 
+Make sure to install proj at version 7 in homebrew:
+ brew install proj@7
+And if proj v. 9 is install, then unlink that with 'brew unlink proj' and then link the v7 with 'brew link proj@7'
 
+Also need to set g++ at as g\+\+-12 so that ncl linking finds the gfortran library.

--- a/README.apple_m1
+++ b/README.apple_m1
@@ -1,0 +1,9 @@
+I have netcdf installed separately and other ncarg dependencies were installed with homebrew. GCC version 12 was installed with homebrew, as well. That version (gcc-12) is wired into the Darwin_Arm configure file and probably should be made generic.
+
+For Configure, my library and include settings are:
+
+/opt/X11/lib /Users/Shared/opt/local/netcdf480ser/lib /Users/Shared/homebrew/lib
+
+/opt/X11/include /opt/X11/include/freetype2 /Users/Shared/opt/local/netcdf480ser/include /Users/Shared/homebrew/include
+
+

--- a/common/src/libncarg_c/yMakefile
+++ b/common/src/libncarg_c/yMakefile
@@ -42,7 +42,16 @@ EXCSRCS = bcopyswap.c logic32.c
 EXFSRCS = gbytes.f sbytes.f
 EXOBJS  = sbytes.o gbytes.o bcopyswap.o logic32.o
 
+#elif defined(Darwin) && defined(arm64) && defined(__LP64__)
+EXCSRCS = bcopyswap.c logic32.c
+EXFSRCS = gbytes.f sbytes.f
+EXOBJS  = sbytes.o gbytes.o bcopyswap.o logic32.o
+
 #elif defined(Darwin) && defined(i386) && !defined(__LP64__)
+EXCSRCS = bcopyswap.c logic32.c gsbytes.c
+EXOBJS  = bcopyswap.o logic32.o gsbytes.o
+
+#elif defined(Darwin) && defined(arm64) && !defined(__LP64__)
 EXCSRCS = bcopyswap.c logic32.c gsbytes.c
 EXOBJS  = bcopyswap.o logic32.o gsbytes.o
 

--- a/config/Darwin_Arm
+++ b/config/Darwin_Arm
@@ -42,9 +42,9 @@
 #define Cdynamic 
 #define CppCommand '/usr/bin/cpp -traditional'
 #define CCompiler   gcc-12
-#define CxxCompiler   g\+\+
+#define CxxCompiler   g\+\+-12
 #define FCompiler   gfortran
-#define CcOptions      -ansi -fPIC -Wall -Wno-error=implicit-function-declaration
+#define CcOptions      -ansi -fPIC -Wall -std=c99 -Wno-error=implicit-function-declaration
 #define FcOptions      -fPIC -fno-range-check -Wall -fallow-argument-mismatch -fallow-invalid-boz
 #define CtoFLibraries      -lgfortran -lquadmath
 #define CtoFLibrariesUser  -lgfortran -lquadmath
@@ -58,6 +58,8 @@
 
 #define ArchRecLibSearch    -L/opt/X11/lib
 #define ArchRecIncSearch    -I/opt/X11/include -I/opt/X11/include/freetype2
+
+#define LexLibrary -ll
 
 FC = $(F77)
 

--- a/config/Darwin_Arm
+++ b/config/Darwin_Arm
@@ -1,18 +1,10 @@
 /*
  *	Description:	This file contains the configuration for a
- *                      gfortran/gcc build on a *32 bit* Intel Mac system.
- *
- *                      If you have Mac OS 10.6 or later, you may have
- *                      a 64-bit system, and hence you should copy
- *                      Darwin_Intel.64 over this file.
+ *                      gfortran/gcc build on a *64 bit* ARM (Apple Silicon) Mac system.
  *
  *                      You may need to modify it to change or include
- *                      options.
- *
- *                      If you want to use a different Fortran compiler
- *                      like g95 or ifort, see the files 
- *                      "Darwin_Intel.g95" or "Darwin_Intel.ifort" in
- *                      this directory for help in modifying this file.
+ *                      options. This version was tested with GCC-12.2
+ *                      built with Homebrew and XCode 13.4.1 on OS 12.6 (Monterey)
  *
  *                       Note: if the build has trouble finding the
  *                       "gfortran" library, then you may need to modify
@@ -31,7 +23,6 @@
  *                       development stuff (like the CtoFLibraries) jammed into those
  *                       scripts, like "/usr/local/lib/libcairo.a"; instead, we want
  *                       clean paths like "-lcairo".
- * #define CcOptions      -ansi -fPIC -Wall -std=c99 
  *  #define CtoFLibraries    -L/Users/Shared/homebrew/Cellar/gcc/12.2.0/lib/gcc/current  -lgfortran -lquadmath
  * #define CtoFLibrariesUser -L/Users/Shared/homebrew/Cellar/gcc/12.2.0/lib/gcc/current -lgfortran -lquadmath
  */

--- a/config/Darwin_Arm
+++ b/config/Darwin_Arm
@@ -1,0 +1,74 @@
+/*
+ *	Description:	This file contains the configuration for a
+ *                      gfortran/gcc build on a *32 bit* Intel Mac system.
+ *
+ *                      If you have Mac OS 10.6 or later, you may have
+ *                      a 64-bit system, and hence you should copy
+ *                      Darwin_Intel.64 over this file.
+ *
+ *                      You may need to modify it to change or include
+ *                      options.
+ *
+ *                      If you want to use a different Fortran compiler
+ *                      like g95 or ifort, see the files 
+ *                      "Darwin_Intel.g95" or "Darwin_Intel.ifort" in
+ *                      this directory for help in modifying this file.
+ *
+ *                       Note: if the build has trouble finding the
+ *                       "gfortran" library, then you may need to modify
+ *                       the "CtoFLibraries" line below and include a "-L"
+ *                       path to help it. For example:
+ *
+ *     #define CtoFLibraries  -L/usr/local/lib -lgfortran -lquadmath
+ *     or
+ *     #define CtoFLibraries  /usr/local/lib/libgfortran.a /usr/local/lib/libquadmath.a
+ *
+ *                       You'll need to change "/usr/local/lib" to
+ *                       whatever directory contains "libgfortran.so".
+ *
+ *			 The references to the "User" macros below is for building the
+ *                       ncargcc, ncargf90, nhlcc, etc, scripts.  We don't want the
+ *                       development stuff (like the CtoFLibraries) jammed into those
+ *                       scripts, like "/usr/local/lib/libcairo.a"; instead, we want
+ *                       clean paths like "-lcairo".
+ * #define CcOptions      -ansi -fPIC -Wall -std=c99 
+ *  #define CtoFLibraries    -L/Users/Shared/homebrew/Cellar/gcc/12.2.0/lib/gcc/current  -lgfortran -lquadmath
+ * #define CtoFLibrariesUser -L/Users/Shared/homebrew/Cellar/gcc/12.2.0/lib/gcc/current -lgfortran -lquadmath
+ */
+#define HdfDefines  -DDARWIN
+#define StdDefines  -DSYSV -D_POSIX_SOURCE -D_XOPEN_SOURCE -DByteSwapped -D__UNIXOS2__ -D_DARWIN_C_SOURCE
+#define ByteSwapped
+#define Cstatic 
+#define Cdynamic 
+#define CppCommand '/usr/bin/cpp -traditional'
+#define CCompiler   gcc-12
+#define CxxCompiler   g\+\+
+#define FCompiler   gfortran
+#define CcOptions      -ansi -fPIC -Wall -Wno-error=implicit-function-declaration
+#define FcOptions      -fPIC -fno-range-check -Wall -fallow-argument-mismatch -fallow-invalid-boz
+#define CtoFLibraries      -lgfortran -lquadmath
+#define CtoFLibrariesUser  -lgfortran -lquadmath
+#define XToolLibrary    -lXt -lSM -lICE
+#define BuildShared NO
+#define XLibrary -lXpm -lX11 -lXext
+
+#define LibSearchUser    -L/opt/X11/lib
+#define IncSearchUser    -I/opt/X11/include -I/opt/X11/include/freetype2
+#define ExtraIncSearch   -I/opt/X11/include/freetype2
+
+#define ArchRecLibSearch    -L/opt/X11/lib
+#define ArchRecIncSearch    -I/opt/X11/include -I/opt/X11/include/freetype2
+
+FC = $(F77)
+
+/*************** Redefine Macros from Rules ********************************/
+
+/*
+ * Macro:	MakeDir
+ *
+ * Description:	This rule creates a directory - if a parent dir doesn't exist
+ *		it attempts to create it.
+ */
+#ifndef MakeDir
+#define MakeDir(dir)    @if (test ! -d dir); then ($(MKDIRHIER) dir); fi
+#endif

--- a/config/Darwin_Arm
+++ b/config/Darwin_Arm
@@ -26,6 +26,7 @@
  *  #define CtoFLibraries    -L/Users/Shared/homebrew/Cellar/gcc/12.2.0/lib/gcc/current  -lgfortran -lquadmath
  * #define CtoFLibrariesUser -L/Users/Shared/homebrew/Cellar/gcc/12.2.0/lib/gcc/current -lgfortran -lquadmath
  */
+#define DEBUG 1
 #define HdfDefines  -DDARWIN
 #define StdDefines  -DSYSV -D_POSIX_SOURCE -D_XOPEN_SOURCE -DByteSwapped -D__UNIXOS2__ -D_DARWIN_C_SOURCE
 #define ByteSwapped
@@ -34,9 +35,9 @@
 #define CppCommand '/usr/bin/cpp -traditional'
 #define CCompiler   gcc-12
 #define CxxCompiler   g\+\+-12
-#define FCompiler   gfortran
-#define CcOptions      -ansi -fPIC -Wall -std=c99 -Wno-error=implicit-function-declaration
-#define FcOptions      -fPIC -fno-range-check -Wall -fallow-argument-mismatch -fallow-invalid-boz
+#define FCompiler   gfortran-12
+#define CcOptions      -ansi -fPIC -Wall -std=c99 -Wno-error=implicit-function-declaration -O
+#define FcOptions      -fPIC -fno-range-check -Wall -fallow-argument-mismatch -fallow-invalid-boz -O
 #define CtoFLibraries      -lgfortran -lquadmath
 #define CtoFLibrariesUser  -lgfortran -lquadmath
 #define XToolLibrary    -lXt -lSM -lICE

--- a/config/ymake
+++ b/config/ymake
@@ -422,6 +422,12 @@ case    Darwin:
             set sysincs = Darwin_Intel
             set vendor  = Apple
             breaksw
+        case    arm64:
+            set model   = $mach
+            set arch    = $mach
+            set sysincs = Darwin_Arm
+            set vendor  = Apple
+            breaksw
         default:
             echo "$0 : Unknown machine type" > /dev/tty
             exit 1

--- a/ncarg2d/src/libncarg/conpack/CodeIftran
+++ b/ncarg2d/src/libncarg/conpack/CodeIftran
@@ -9666,9 +9666,6 @@ C
 C Find the length of the character buffer and initialize it to blanks.
 C
         LBUF=LEN(CBUF)
-C  hack: Check if lbuf is "large" and, if it is, assume calling from C 
-C    and length is bad and should be 128
-        IF ( LBUF > 512 ) LBUF = 128 
         CBUF(1:lbuf)=' '
 C
 C Use the local I/O routines to generate an E-format representation of

--- a/ncarg2d/src/libncarg/conpack/CodeIftran
+++ b/ncarg2d/src/libncarg/conpack/CodeIftran
@@ -9666,7 +9666,10 @@ C
 C Find the length of the character buffer and initialize it to blanks.
 C
         LBUF=LEN(CBUF)
-        CBUF=' '
+C  hack: Check if lbuf is "large" and, if it is, assume calling from C 
+C    and length is bad and should be 128
+        IF ( LBUF > 512 ) LBUF = 128 
+        CBUF(1:lbuf)=' '
 C
 C Use the local I/O routines to generate an E-format representation of
 C the number.
@@ -9788,7 +9791,7 @@ C which requires special action).
 C
         IF (NDGS.EQ.0.OR.IEXF.EQ.0)
           IF (IEXP.GT.0.OR.LMSD.EQ.-10000)
-            CBUF='0'
+            CBUF(1:LBUF)='0'
             NBUF=1
             NDGS=1
             IEVA=0

--- a/ncarg2d/src/libncarg_gks/bwi/argb2ci.f
+++ b/ncarg2d/src/libncarg_gks/bwi/argb2ci.f
@@ -16,10 +16,14 @@ C
       integer index, nearest
       integer i
       integer ARGBMASK, RMASK, GMASK, BMASK
-      parameter (ARGBMASK = Z'40000000')
-      parameter (RMASK     = Z'00FF0000')
-      parameter (GMASK     = Z'0000FF00')
-      parameter (BMASK     = Z'000000FF')
+      parameter (ARGBMASK  = int(Z'40000000'))
+      parameter (RMASK     = int(Z'00FF0000'))
+      parameter (GMASK     = int(Z'0000FF00'))
+      parameter (BMASK     = int(Z'000000FF'))
+!      parameter (ARGBMASK = Z'40000000')
+!      parameter (RMASK     = Z'00FF0000')
+!      parameter (GMASK     = Z'0000FF00')
+!      parameter (BMASK     = Z'000000FF')
       real r, g, b, dist, mindist
 
       if (iand(index, ARGBMASK).eq.0) then
@@ -31,8 +35,8 @@ C     find the closest match, based upon distance in color space
       mindist = 2e31
       nearest = 0
       do i=1,mol
-          r = (iand(index, RMASK) / Z'0000FFFF') / 255.
-          g = (iand(index, GMASK) / Z'000000FF') / 255.
+          r = (iand(index, RMASK) / int(Z'0000FFFF')) / 255.
+          g = (iand(index, GMASK) / int(Z'000000FF')) / 255.
           b = (iand(index, BMASK))               / 255.
 
 C         we don't need absolute distance, so forego the sqrt operation...

--- a/ni/src/lib/hlu/Format.c
+++ b/ni/src/lib/hlu/Format.c
@@ -940,11 +940,7 @@ NhlString _NhlFormatFloat
         NGCALLF(cpinrc,CPINRC)();
 
 	{
-#ifdef arm64
-		long int len1,len2,len3,len4;
-#else
-		int len1,len2,len3,len4;
-#endif
+		long len1,len2,len3,len4;
 		NGstring cex1_f;
 		NGstring cex2_f;
 		NGstring cex3_f;
@@ -1287,11 +1283,7 @@ NhlErrorTypes _NhlGetScaleInfo
         NGCALLF(cpinrc,CPINRC)();
 
 	{
-#ifdef arm64
-		long int len1,len2,len3,len4;
-#else
-		int len1,len2,len3,len4;
-#endif
+		long len1,len2,len3,len4;
 		NGstring cex1_f;
 		NGstring cex2_f;
 		NGstring cex3_f;

--- a/ni/src/lib/hlu/Format.c
+++ b/ni/src/lib/hlu/Format.c
@@ -940,7 +940,11 @@ NhlString _NhlFormatFloat
         NGCALLF(cpinrc,CPINRC)();
 
 	{
+#ifdef arm64
+		long int len1,len2,len3,len4;
+#else
 		int len1,len2,len3,len4;
+#endif
 		NGstring cex1_f;
 		NGstring cex2_f;
 		NGstring cex3_f;
@@ -1283,7 +1287,11 @@ NhlErrorTypes _NhlGetScaleInfo
         NGCALLF(cpinrc,CPINRC)();
 
 	{
+#ifdef arm64
+		long int len1,len2,len3,len4;
+#else
 		int len1,len2,len3,len4;
+#endif
 		NGstring cex1_f;
 		NGstring cex2_f;
 		NGstring cex3_f;

--- a/ni/src/lib/hlu/yMakefile
+++ b/ni/src/lib/hlu/yMakefile
@@ -48,7 +48,7 @@ Qt_DEFINES      = -DBuildQtEnabled
 #define Qt_DEFINES
 #endif
 
-EXTRA_CDEFINES	=	$(OS_DEF) $(TRIANGLE_DEF) $(PNG_DEF) $(Qt_DEFINES) $(ARCH_DEF)
+EXTRA_CDEFINES	=	$(OS_DEF) $(TRIANGLE_DEF) $(PNG_DEF) $(Qt_DEFINES)
 
 HDRS1   	= Base.h BaseI.h BaseP.h Convert.h ConvertP.h ConvertersP.h\
 		CoordApprox.h Error.h ErrorI.h ErrorP.h IrregularTransObj.h \

--- a/ni/src/lib/hlu/yMakefile
+++ b/ni/src/lib/hlu/yMakefile
@@ -48,7 +48,7 @@ Qt_DEFINES      = -DBuildQtEnabled
 #define Qt_DEFINES
 #endif
 
-EXTRA_CDEFINES	=	$(OS_DEF) $(TRIANGLE_DEF) $(PNG_DEF) $(Qt_DEFINES)
+EXTRA_CDEFINES	=	$(OS_DEF) $(TRIANGLE_DEF) $(PNG_DEF) $(Qt_DEFINES) $(ARCH_DEF)
 
 HDRS1   	= Base.h BaseI.h BaseP.h Convert.h ConvertP.h ConvertersP.h\
 		CoordApprox.h Error.h ErrorI.h ErrorP.h IrregularTransObj.h \

--- a/ni/src/lib/nfpfort/yMakefile
+++ b/ni/src/lib/nfpfort/yMakefile
@@ -41,7 +41,7 @@ FOBJS = aam.o areaAve.o areaAve2.o areaRmse.o areaRmse2.o areaSum2.o	\
 	det_code42.o kmeans_kmns_as136.o spi3.o wrf_vinterp.o wrf_fctt.o \
 	wrf_write_wps.o pres_hybrid_jra55_dp.o relhum_ice.o relhum_water.o \
 	wetbulb_profs.o wrf_cloud_fracf.o mlegev_memory.o kernel_density.o \
-	meemd.o dpsort_large.o wrf_pw.o wrf_wind.o wrf_constants.o wrf_constants.mod
+	meemd.o dpsort_large.o wrf_pw.o wrf_wind.o wrf_constants.o 
 
 COBJS =
 


### PR DESCRIPTION
This provides fixes for compiling on Apple M processors for anybody who is interested. The libraries work for linking/running Fortran programs. Ncl seg fault on contour plots is also fixed.
Note: compiled/tested without grib, hdf4, hdfeos5 -- just netcdf4.

Build setup:
   Macos 12.6 (Monterey) 
   Xcode 13.4.1
   gcc/gfortran 12.2 (via homebrew)
   XQuartz 2.8.1
   Homebrew (for almost all library dependencies; note must use proj@7 as it fails with 8+)
   netcdf-4.9.0 (w/ hdf5)

For Ventura: 
  Xcode 14.3.1
  gcc-12/gfortran-12 (probably would work also with v11 or 13, but not tested)
  XQuartz 2.8.5

Probably could use macports libraries to do a full build (i.e., support grib etc.), but I haven't tried that yet.
