### PR TITLE
wrf_constants.mod in FOBJ

### DIFF
--- a/ni/src/lib/nfpfort/yMakefile
+++ b/ni/src/lib/nfpfort/yMakefile
@@ -41,7 +41,7 @@ FOBJS = aam.o areaAve.o areaAve2.o areaRmse.o areaRmse2.o areaSum2.o	\
 	det_code42.o kmeans_kmns_as136.o spi3.o wrf_vinterp.o wrf_fctt.o \
 	wrf_write_wps.o pres_hybrid_jra55_dp.o relhum_ice.o relhum_water.o \
 	wetbulb_profs.o wrf_cloud_fracf.o mlegev_memory.o kernel_density.o \
-	meemd.o dpsort_large.o wrf_pw.o wrf_wind.o wrf_constants.o wrf_constants.mod
+	meemd.o dpsort_large.o wrf_pw.o wrf_wind.o wrf_constants.o
 
 COBJS =
 


### PR DESCRIPTION
A module file should not be included in archive. It causes a link problem of ncl executable on macOS with Command Line Tools 14.