### PR TITLE
pass CI on ubuntu-latest

### DIFF
--- a/.build/envs/Darwin.yml
+++ b/.build/envs/Darwin.yml
@@ -16,7 +16,7 @@ dependencies:
   - hdfeos2
   - hdfeos5
   - imagemagick
-  - jasper
+  - jasper=1.900.1
   - jpeg
   - libgdal=2.4
   - libiconv

--- a/.build/envs/Linux.yml
+++ b/.build/envs/Linux.yml
@@ -18,7 +18,7 @@ dependencies:
   - hdfeos2
   - hdfeos5
   - imagemagick
-  - jasper
+  - jasper=1.900.1
   - jpeg
   - libgdal
   - libiconv

--- a/.github/workflows/ci_mamba.yml
+++ b/.github/workflows/ci_mamba.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'develop'
       - 'master'
+      - 'github_actions'
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/ci_mamba.yml
+++ b/.github/workflows/ci_mamba.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - 'develop'
       - 'master'
-      - 'github_actions'
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
By specifying jasper version `1.900.1`, CI test is able to be passed on ubuntu-latest