### PR TITLE
Add build support for loongarch64

### DIFF
--- a/config/ymake
+++ b/config/ymake
@@ -367,6 +367,7 @@ case    Linux:
         case    x*64:
         case    p*64:
         case    alpha:
+        case    loongarch64:
             set model   = $mach
             set arch    = $mach
             set sysincs = LINUX


### PR DESCRIPTION
Hi maintainer,

Compiling the ncl failed for loong64 in the Debian Package Auto-Building environment.
The error log is as follows,
```
Making ymake from Makefile.ini in ./config first
make[2]: Entering directory '/<<PKGBUILDDIR>>/config'
cc -O -Wdate-time -D_FORTIFY_SOURCE=2  -c -o ymake-filter.o ymake-filter.c
cc -O -o ymake-filter ymake-filter.o
make[2]: Leaving directory '/<<PKGBUILDDIR>>/config'

Continuing in: /<<PKGBUILDDIR>>
./config/ymake : Unknown machine type
Unable to build Makefile - fix above errors and re-run.
```

Please consider and review this commit.
Based on this commit, now debian ncl was built successfully for loongarch64.
The details can be found at https://buildd.debian.org/status/logs.php?pkg=ncl&ver=6.6.2.dfsg.1-9.1&arch=loong64.

Best regards,
Dandan