### PR TITLE
Fix declaration of isacppcomment()

### DIFF
--- a/config/ymake-filter.c
+++ b/config/ymake-filter.c
@@ -47,7 +47,7 @@ int main()
 {
 	char	*line, *getcppline();
 	int	len, lastlen;
-	int	isacppcomment();
+	int	isacppcomment(char *);
 
 	lastlen = 0;
 


### PR DESCRIPTION
gcc 15 enables C23 standard which requires declaration of function arguments.